### PR TITLE
fix: Update branding import in `surveymonkey.py`

### DIFF
--- a/surveymonkey/surveymonkey.py
+++ b/surveymonkey/surveymonkey.py
@@ -5,7 +5,7 @@ If the mode track-able is selected, the user anonymous id will be sent as a quer
 import logging
 import pkg_resources
 
-from branding import api as branding_api
+from lms.djangoapps.branding import api as branding_api
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 from lms.djangoapps.courseware.courses import get_course_by_id


### PR DESCRIPTION
### Description
This PR makes a little fix to the block in order to be used in lilac versions.

Update the way to import branding without **DeprecatedEdxPlatformImportError.**


**error:**
`DeprecatedEdxPlatformImportError Traceback (most recent call last) <ipython-input-1-e5738dd0a04a> in <module> ----> 1 import surveymonkey as sm /openedx/venv/lib/python3.8/site-packages/surveymonkey/__init__.py in <module> ----> 1 from .surveymonkey import SurveyMonkeyXBlock /openedx/venv/lib/python3.8/site-packages/surveymonkey/surveymonkey.py in <module> 5 import logging 6 import pkg_resources ----> 8 from branding import api as branding_api 9 from django.conf import settings 10 from django.utils.translation import ugettext_lazy as _ /openedx/edx-platform/import_shims/lms/branding/__init__.py in <module> 2 # pylint: disable=redefined-builtin,wrong-import-position,wildcard-import,useless-suppression,line-too-long 4 from import_shims.warn import warn_deprecated_import ----> 6 warn_deprecated_import('branding', 'lms.djangoapps.branding') 8 from lms.djangoapps.branding import * /openedx/edx-platform/import_shims/warn.py in warn_deprecated_import(old_import, new_import) 27 def warn_deprecated_import(old_import, new_import): 28 """ 29 Raise an error that a module is being imported from an unsupported location. 30 (...) 35 the Lilac release is cut. 36 """ ---> 37 raise DeprecatedEdxPlatformImportError(old_import, new_import) DeprecatedEdxPlatformImportError: Importing branding instead of lms.djangoapps.branding is deprecated.`
